### PR TITLE
Added config error handling and tests

### DIFF
--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	config := config.New()
+	config := config.New("./environments")
 	logLevel := config.GetStringSetting("logs.level")
 	fmt.Printf("\nLogging at level: %s", logLevel)
 	fmt.Println()

--- a/cmd/game/main.go
+++ b/cmd/game/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	config := config.New()
+	config := config.New("./environments")
 	logLevel := config.GetStringSetting("logs.level")
 	fmt.Printf("\nLogging at level: %s", logLevel)
 	fmt.Println()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestNew_PanicsWhenEnvConfigFileNotFound(t *testing.T) {
+	defer func() { osEnvFunction = os.Getenv
+		fmt.Println("osEnvFunction reset back to os.Getenv")
+	}()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The New function should have paniced")
+		}
+	}()
+	osEnvFunction = func(string) string {
+		fmt.Println("in the mock")
+		return "Not an Environment. Should panic"
+	}
+
+	// The following is the code under test
+	New("./../environments")
+}
+
+func TestGetStringSetting(t *testing.T) {
+	config := New("./../environments")
+
+	// The logs.level setting should always be at debug for local testing
+	got := config.GetStringSetting("logs.level")
+	if got != "debug" {
+		fmt.Printf("Expected debug got %v", got)
+	}
+}


### PR DESCRIPTION
Added config error handling and tests

Need to pass folder into the config because folder path is different for the tests - it also allows the two apps to have different configs later if needed

