### PR TITLE
Readability on test output

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/judewood/bakery/myfmt"
 )
 
 func TestNew_PanicsWhenEnvConfigFileNotFound(t *testing.T) {
-	defer func() { osEnvFunction = os.Getenv
+	defer func() {
+		osEnvFunction = os.Getenv
 		fmt.Println("osEnvFunction reset back to os.Getenv")
 	}()
 	defer func() {
 		if r := recover(); r == nil {
-			t.Errorf("The New function should have paniced")
+			myfmt.Errorf(t, "The New function should have paniced")
 		}
 	}()
 	osEnvFunction = func(string) string {

--- a/internal/bakers/cake_baker_service_test.go
+++ b/internal/bakers/cake_baker_service_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/judewood/bakery/internal/orders"
 	"github.com/judewood/bakery/internal/recipes"
+	"github.com/judewood/bakery/myfmt"
 )
 
 func TestBake(t *testing.T) {
@@ -55,10 +56,10 @@ func TestBake(t *testing.T) {
 		gotError := cakeBaker.Bake(testCase.Input)
 
 		if testCase.err == nil && gotError != nil {
-			t.Errorf("Failed TestBake.\nGot Error %v", gotError.Error())
+			myfmt.Errorf(t,"Failed TestBake.\nGot Error %v", gotError.Error())
 		}
 		if testCase.err != nil && gotError == nil {
-			t.Errorf("Failed TestBake.\nExpected Error %v", testCase.err)
+			myfmt.Errorf(t, "Failed TestBake.\nExpected Error %v", testCase.err)
 		}
 	}
 

--- a/internal/orders/orders_test.go
+++ b/internal/orders/orders_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/judewood/bakery/internal/products"
+	"github.com/judewood/bakery/myfmt"
 	"github.com/judewood/bakery/random"
 )
 
@@ -48,14 +49,15 @@ func TestRandomOrder(t *testing.T) {
 		order, gotError := NewOrder(mockProductStore, mockRandom).RandomOrder()
 
 		if !reflect.DeepEqual(testCase.wantItems, order.Items) {
-			t.Errorf("Failed TestRandomOrder. \nWanted %v\nGot %v", wantedItems, order.Items)
+			myfmt.Errorf(t, "Failed TestRandomOrder. \nWanted %v\nGot %v", wantedItems, order.Items)
 		}
 		if testCase.wantError == nil && gotError != nil {
-			t.Errorf("Failed TestRandomOrder.\nGot Error %v", gotError.Error())
+			myfmt.Errorf(t, "Failed TestRandomOrder.\nGot Error %v", gotError.Error())
 		}
 		if testCase.wantError != nil && gotError == nil {
-			t.Errorf("Failed TestRandomOrder.\nExpected Error %v", testCase.wantError)
+			myfmt.Errorf(t, "Failed TestRandomOrder.\nExpected Error %v", testCase.wantError)
 		}
+		t.Log()
 	}
 }
 

--- a/internal/products/product_service_test.go
+++ b/internal/products/product_service_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/judewood/bakery/myfmt"
 )
 
 var sampleProducts = []Product{
@@ -34,15 +36,15 @@ func TestGetAvailableProducts(t *testing.T) {
 		gotProducts, gotError := productService.GetAvailableProducts()
 
 		if !reflect.DeepEqual(gotProducts, testCase.want) {
-			t.Errorf("Failed TestGetAvailableProducts.\nWanted: %v \nGot %v", testCase.want, gotProducts)
+			myfmt.Errorf(t, "Failed TestGetAvailableProducts.\nWanted: %v \nGot %v", testCase.want, gotProducts)
 		}
 
 		if testCase.err == nil && gotError != nil {
-			t.Errorf("Failed TestGetAvailableProducts.\nGot Error %v", gotError.Error())
+			myfmt.Errorf(t, "Failed TestGetAvailableProducts.\nGot Error %v", gotError.Error())
 		}
 
 		if testCase.err != nil && gotError == nil {
-			t.Errorf("Failed TestGetAvailableProducts.\nExpected Error %v", testCase.err.Error())
+			myfmt.Errorf(t, "Failed TestGetAvailableProducts.\nExpected Error %v", testCase.err.Error())
 		}
 
 	}
@@ -54,6 +56,6 @@ func TestFormatProducts(t *testing.T) {
 	got := FormatProducts(sampleProducts)
 
 	if got != want {
-		t.Errorf("Failed TestFormatProducts. \nWanted:\n *%v*\nGot:\n *%v*", want, got)
+		myfmt.Errorf(t, "Failed TestFormatProducts. \nWanted:\n *%v*\nGot:\n *%v*", want, got)
 	}
 }

--- a/internal/recipes/recipe_store.go
+++ b/internal/recipes/recipe_store.go
@@ -17,7 +17,6 @@ type Recipe struct {
 	BakeTime    int          `json:"bakeTime"`
 }
 
-
 // Recipes is in memory store of recipe for each product that the bakery sells
 var Recipes = map[string]Recipe{
 	"1": {

--- a/myfmt/myfmt.go
+++ b/myfmt/myfmt.go
@@ -1,0 +1,9 @@
+package myfmt
+
+import "testing"
+
+const ThumbsDown = "\U0001f44e"
+
+func Errorf(t *testing.T, s string , args... any) {
+	t.Errorf(ThumbsDown + s, args)
+}


### PR DESCRIPTION
Failed tests now display a yellow thumbs down emoji in the console output. 

Scan of alternatives for this functionality showed that they either needed command line setup or machine setup - this way seems simpler and lets me find test failures quickly