### PR TITLE
Simplified and improved error handling

### DIFF
--- a/internal/bakers/cake_baker_service_test.go
+++ b/internal/bakers/cake_baker_service_test.go
@@ -34,7 +34,7 @@ func TestBake(t *testing.T) {
 
 	testCases := []TestCase{
 		{"found", sampleProductQuantity[0], sampleRecipe, nil},
-		{"missing", sampleProductQuantity[1], recipes.Recipe{}, errorutils.NotFoundError("missing")},
+		{"missing", sampleProductQuantity[1], recipes.Recipe{}, errorutils.ErrorNotFound},
 	}
 	mockRecipeCache := recipes.NewMockRecipeCache()
 	for i, test := range testCases {

--- a/internal/orders/order_service.go
+++ b/internal/orders/order_service.go
@@ -43,7 +43,6 @@ func NewOrder(productStorer products.ProductStorer, random random.RandomProvider
 
 		err := opt(&options)
 		if err != nil {
-			fmt.Println("TODO")
 			return nil, err
 		}
 	}
@@ -58,7 +57,6 @@ func NewOrder(productStorer products.ProductStorer, random random.RandomProvider
 func (o *Order) CreateOrder() error {
 	items, err := o.GetRandomItems()
 	if err != nil {
-		fmt.Println("TODO")
 		return err
 	}
 	o.Items = items

--- a/internal/products/product_controller.go
+++ b/internal/products/product_controller.go
@@ -1,7 +1,7 @@
 package products
 
 import (
-	"fmt"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -40,11 +40,11 @@ func (p *ProductController) Get(ctx *gin.Context) {
 	product, err := p.productService.Get(id)
 
 	if err != nil {
-		if err.Error() == errorutils.MissingID {
+		if errors.Is(err, errorutils.ErrorMissingID) {
 			ctx.JSON(http.StatusBadRequest, "")
 			return
 		}
-		if err.Error() == fmt.Sprintf(errorutils.NotFound, id) {
+		if errors.Is(err, errorutils.ErrorNotFound) {
 			ctx.JSON(http.StatusNoContent, "")
 			return
 		}
@@ -65,7 +65,7 @@ func (p *ProductController) Add(ctx *gin.Context) {
 	slog.Debug("Add product request", "product", product)
 	added, err := p.productService.Add(product)
 	if err != nil {
-		if err.Error() == errorutils.MissingRequired {
+		if errors.Is(err, errorutils.ErrorMissingRequired) {
 			ctx.JSON(http.StatusBadRequest, "")
 			return
 		}
@@ -86,11 +86,11 @@ func (p *ProductController) Update(ctx *gin.Context) {
 	slog.Debug("Update product request", "product", product)
 	added, err := p.productService.Update(product)
 	if err != nil {
-		if err.Error() == errorutils.MissingRequired {
+		if errors.Is(err, errorutils.ErrorMissingRequired) {
 			ctx.JSON(http.StatusBadRequest, "")
 			return
 		}
-		if err.Error() == errorutils.NotFoundError(product.Name).Error() {
+		if errors.Is(err, errorutils.ErrorNotFound) {
 			ctx.JSON(http.StatusNoContent, "")
 			return
 		}
@@ -105,13 +105,12 @@ func (p *ProductController) Delete(ctx *gin.Context) {
 	slog.Debug("Delete by id request", "id", id)
 
 	product, err := p.productService.Delete(id)
-
 	if err != nil {
-		if err.Error() == errorutils.MissingID {
+		if errors.Is(err, errorutils.ErrorMissingID) {
 			ctx.JSON(http.StatusBadRequest, "")
 			return
 		}
-		if err.Error() == errorutils.NotFoundError(id).Error() {
+		if errors.Is(err, errorutils.ErrorNotFound) {
 			ctx.JSON(http.StatusNoContent, "")
 			return
 		}

--- a/internal/products/product_controller_test.go
+++ b/internal/products/product_controller_test.go
@@ -88,7 +88,7 @@ func TestProductControllerGet(t *testing.T) {
 	}
 	testCases := []testCase{
 		{name: "product exists", reqId: strings.ToLower(sampleProducts[2].Name), respProduct: sampleProducts[2], status: http.StatusOK, err: nil},
-		{name: "product does not exist", reqId: "missing", respProduct: Product{}, status: http.StatusNoContent, err: errorutils.NotFoundError("missing")},
+		{name: "product does not exist", reqId: "missing", respProduct: Product{}, status: http.StatusNoContent, err: errorutils.ErrorNotFound},
 		{name: "requested id is invalid", reqId: "a", respProduct: Product{}, status: http.StatusBadRequest, err: errorutils.ErrorMissingID},
 	}
 	t.Log("Given that I have the http server running")
@@ -218,7 +218,7 @@ func TestProductControllerUpdate(t *testing.T) {
 		{name: "missing product name", reqBody: Product{Name: "", RecipeID: "4"}, respBody: Product{}, status: http.StatusBadRequest, err: errorutils.ErrorMissingRequired},
 		{name: "missing recipeID", reqBody: Product{Name: "product name", RecipeID: ""}, respBody: Product{}, status: http.StatusBadRequest, err: errorutils.ErrorMissingRequired},
 		{name: "not a product", reqBody: "Not a product", respBody: Product{}, status: http.StatusBadRequest, err: errorutils.ErrorMissingRequired},
-		{name: "not found", reqBody: Product{Name: "missing", RecipeID: "4"}, respBody: Product{}, status: http.StatusNoContent, err: errorutils.NotFoundError("missing")},
+		{name: "not found", reqBody: Product{Name: "missing", RecipeID: "4"}, respBody: Product{}, status: http.StatusNoContent, err: errorutils.ErrorNotFound},
 	}
 	t.Log("Given that I have the http server running")
 	{
@@ -282,7 +282,7 @@ func TestProductControllerDelete(t *testing.T) {
 	testCases := []testCase{
 
 		{name: "product exists", reqId: strings.ToLower(sampleProducts[2].Name), respProduct: sampleProducts[2], status: http.StatusOK, err: nil},
-		{name: "product does not exist", reqId: "missing", respProduct: Product{}, status: http.StatusNoContent, err: errorutils.NotFoundError("missing")},
+		{name: "product does not exist", reqId: "missing", respProduct: Product{}, status: http.StatusNoContent, err: errorutils.ErrorNotFound},
 		{name: "requested id is invalid", reqId: "a", respProduct: Product{}, status: http.StatusBadRequest, err: errorutils.ErrorMissingID},
 	}
 	t.Log("Given that I want to delete a product")

--- a/internal/products/product_service_test.go
+++ b/internal/products/product_service_test.go
@@ -81,7 +81,7 @@ func TestProductServiceGet(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{name: "missing", input: "invalid", want: Product{}, err: errorutils.NotFoundError("missing")},
+		{name: "missing", input: "invalid", want: Product{}, err: errorutils.ErrorNotFound},
 		{name: "invalid id", input: "x", want: Product{}, err: errorutils.ErrorMissingID},
 		{name: "valid", input: "Vanilla cake", want: sampleProducts[0], err: nil},
 	}
@@ -211,7 +211,7 @@ func TestProductServiceUpdate(t *testing.T) {
 		{name: "empty", input: Product{}, want: Product{}, err: mockError},
 		{name: "missing recipe id", input: Product{Name: "productName", RecipeID: ""}, want: Product{}, err: mockError},
 		{name: "missing product name", input: Product{Name: "", RecipeID: "RecipeId"}, want: Product{}, err: mockError},
-		{name: "missing", input: updatedProduct, want: Product{}, err: errorutils.NotFoundError("missing")},
+		{name: "missing", input: updatedProduct, want: Product{}, err: errorutils.ErrorNotFound},
 		{name: "valid", input: updatedProduct, want: updatedProduct, err: nil},
 	}
 
@@ -271,7 +271,7 @@ func TestProductServiceDelete(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{name: "does not exist", input: "missing", want: Product{}, err: errorutils.NotFoundError("missing")},
+		{name: "does not exist", input: "missing", want: Product{}, err: errorutils.ErrorNotFound},
 		{name: "invalid id", input: "x", want: Product{}, err: errorutils.ErrorMissingID},
 		{name: "exists", input: "Vanilla cake", want: sampleProducts[0], err: nil},
 	}

--- a/internal/products/product_store.go
+++ b/internal/products/product_store.go
@@ -44,7 +44,7 @@ func (p *ProductStore) Get(id string) (Product, error) {
 			return v, nil
 		}
 	}
-	return Product{}, errorutils.NotFoundError(id)
+	return Product{}, errorutils.ErrorNotFound
 }
 
 // Add adds given product to the store if it is a valid product
@@ -61,7 +61,7 @@ func (p *ProductStore) Update(product Product) (Product, error) {
 			return product, nil
 		}
 	}
-	return Product{}, errorutils.NotFoundError(product.Name)
+	return Product{}, errorutils.ErrorNotFound
 }
 
 // Delete deletes and returns matching product or empty product if not found
@@ -77,5 +77,5 @@ func (p *ProductStore) Delete(id string) (Product, error) {
 		}
 
 	}
-	return Product{}, errorutils.NotFoundError(id)
+	return Product{}, errorutils.ErrorNotFound
 }

--- a/internal/recipes/recipe_store.go
+++ b/internal/recipes/recipe_store.go
@@ -2,6 +2,7 @@ package recipes
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/judewood/bakery/internal/s3client"
@@ -50,8 +51,7 @@ func (r *RecipeStore) GetRecipeFromS3(id string) (Recipe, error) {
 	}
 	err = json.Unmarshal(response, &recipe)
 	if err != nil {
-		slog.Warn("failed to deserialise recipe form S3", "error", err)
-		return Recipe{}, err
+		return Recipe{}, fmt.Errorf("failed to deserialise recipe from S3: %w", err)
 	}
 	slog.Debug("received recipe from S3", "recipe", recipe)
 	return recipe, nil

--- a/internal/s3client/s3client.go
+++ b/internal/s3client/s3client.go
@@ -25,8 +25,11 @@ func (s *S3Client) GetDataFromS3(url string) ([]byte, error) {
 		Timeout: time.Second * 10,
 	}
 	response, err := client.Get(url)
-	if err != nil || response == nil {
-		slog.Warn("failed to get response from S3", "error", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response from S3 url : %s. Error: %w", url, err)
+	}
+	if response == nil {
+		return nil, fmt.Errorf("failed to get response from S3 url : %s", url)
 	}
 	slog.Debug("Status code from S3 request", "code", response.StatusCode)
 	switch response.StatusCode {

--- a/utils/errorutils/errorutils.go
+++ b/utils/errorutils/errorutils.go
@@ -2,27 +2,14 @@ package errorutils
 
 import (
 	"errors"
-	"fmt"
 )
 
-const NotFound string = "id: %s not found"
-
-// NotFoundError returns a consistently formatted
-// error for when an entity cannot be found 
-func NotFoundError(s string) error {
-	return fmt.Errorf(NotFound, s)
-}
-
-// MissingRequired is consistent text for failed validation due to missing required field
-const MissingRequired string = "missing required field"
-
-// MissingID is consistent text for failed validation due to missing or badly formatted identifier in input
-const MissingID = "missing id in request"
+var ErrorNotFound = errors.New("not found")
 
 // ErrorMissingID returns a consistently formatted
-// error for a missing or badly formatted input identifier 
-var ErrorMissingID = errors.New(MissingID)
+// error for a missing or badly formatted input identifier
+var ErrorMissingID = errors.New("missing id in request")
 
 // ErrorMissingRequired returns a consistently formatted
-// error for a missing required field 
-var ErrorMissingRequired = errors.New(MissingRequired)
+// error for a missing required field
+var ErrorMissingRequired = errors.New("missing required field")

--- a/utils/testutils/testutils.go
+++ b/utils/testutils/testutils.go
@@ -25,7 +25,7 @@ func FailedToDeserialise(t *testing.T, body any) {
 	t.Errorf("\n%s testutils.Failed to deserialise the response: %v", ThumbsDown, body)
 }
 
-// FailedToDeserialise prints a yellow thumbs down emoji followed by 
+// FailedToDeserialise returns prefixed with a yellow thumbs down emoji followed by 
 // the fail reason and the given input stream that could not be read
 // and prints it to the test output for improved readability
 func FailedToReadResponse(t *testing.T, err error) {

--- a/utils/tracing/tracing.go
+++ b/utils/tracing/tracing.go
@@ -2,7 +2,7 @@ package tracing
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"runtime/trace"
 )
@@ -12,12 +12,12 @@ func StartTrace() *os.File {
 	// Create a file to store the trace output
 	f, err := os.Create("trace.out")
 	if err != nil {
-		log.Fatalf("failed to create trace output file: %v", err)
+		slog.Warn("failed to create trace output file: %v", "error", err)
 	}
 
 	// Start the trace
 	if err := trace.Start(f); err != nil {
-		log.Fatalf("failed to start trace: %v", err)
+		slog.Warn("failed to start trace: %v", "error", err)
 	}
 	fmt.Println("Tracing started")
 	return f


### PR DESCRIPTION
Using errors.Is to simplify error checks
handling errors by either logging or handling the error
failure to trace no longer fatal - logged warning instead
